### PR TITLE
Use lowercase boolean names in JSON files.

### DIFF
--- a/config/oauth.settings.json
+++ b/config/oauth.settings.json
@@ -1,6 +1,6 @@
 {
     "_config_name": "oauth_common.settings",
-    "oauth_common_enable_provider": TRUE,
+    "oauth_common_enable_provider": true,
     "oauth_common_request_token_lifetime": 7200,
     "oauth_common_login_path": "OAUTH_COMMON_LOGIN_PATH"
 }


### PR DESCRIPTION
Hi @Graham-72! PHP may run into a parsing error importing this JSON file unless the Booleans are lower case. In JavaScript, `TRUE` would be an undefined variable, but `true` is the Boolean value. 